### PR TITLE
Add SDF example protocol bindings and CDDL schema

### DIFF
--- a/jkrhb/sdf-binding-example.json
+++ b/jkrhb/sdf-binding-example.json
@@ -1,0 +1,87 @@
+{
+    "sdfObject": {
+        "Switch": {
+            "sdfProperty": {
+                "value": {
+                    "bindings": {
+                        "readSdfProperty": [
+                            {
+                                "protocol": "coap",
+                                "href": "/switch/value",
+                                "method": "GET"
+                            }
+                        ],
+                        "writeSdfProperty": [
+                            {
+                                "protocol": "coap",
+                                "href": "/switch/value",
+                                "method": "PUT"
+                            }
+                        ],
+                        "observeSdfProperty": [
+                            {
+                                "protocol": "coap",
+                                "href": "/switch/value",
+                                "method": "GET",
+                                "options": [
+                                    {
+                                        "name": "Observe",
+                                        "value": 0
+                                    }
+                                ]
+                            }
+                        ],
+                        "unobserveSdfProperty": [
+                            {
+                                "protocol": "coap",
+                                "href": "/switch/value",
+                                "method": "GET",
+                                "options": [
+                                    {
+                                        "name": "Observe",
+                                        "value": 1
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "sdfAction": {
+                "on": {
+                    "bindings": {
+                        "invokeSdfAction": [
+                            {
+                                "protocol": "coap",
+                                "href": "/switch/on",
+                                "method": "POST"
+                            }
+                        ]
+                    }
+                },
+                "off": {
+                    "bindings": {
+                        "invokeSdfAction": [
+                            {
+                                "protocol": "coap",
+                                "href": "/switch/off",
+                                "method": "POST"
+                            }
+                        ]
+                    }
+                },
+                "toggle": {
+                    "bindings": {
+                        "invokeSdfAction": [
+                            {
+                                "protocol": "coap",
+                                "href": "/switch/toggle",
+                                "method": "POST"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jkrhb/sdf-binding-reversed-example.json
+++ b/jkrhb/sdf-binding-reversed-example.json
@@ -1,0 +1,81 @@
+{
+    "info": {
+        "title": "Example protocol bindings for OneDM Semantic Definition Format",
+        "description": "This document defines example protocol bindings for OneDM Semantic Definition Format",
+        "id": "urn:foo:bar:9001-Lightswitch-43"
+    },
+    "sdfSecurity": {
+        "nosec_sc": { "scheme": "nosec" },
+        "psk_sc": { "scheme": "psk" }
+    },
+    "sdfBindings": {
+        "coap": {
+            "defaultSecurity": ["psk_sc"],
+            "host": "lightswitch.example.org",
+            "port": 5683,
+            "/switch/value": {
+                "readProperty": [
+                    {
+                        "method": "GET",
+                        "affordance": "sdfObject/Switch/sdfProperty/value",
+                        "security": "nosec_sc"
+                    }
+                ],
+                "writeProperty": [
+                    {
+                        "method": "PUT",
+                        "affordance": "sdfObject/Switch/sdfProperty/value"
+                    }
+                ],
+                "observeProperty": [
+                    {
+                        "method": "GET",
+                        "affordance": "sdfObject/Switch/sdfProperty/value",
+                        "options": [
+                            {
+                                "name": "Observe",
+                                "value": 0
+                            }
+                        ]
+                    }
+                ],
+                "unobserveProperty": [
+                    {
+                        "method": "GET",
+                        "affordance": "sdfObject/Switch/sdfProperty/value",
+                        "options": [
+                            {
+                                "name": "Observe",
+                                "value": 1
+                            }
+                        ]
+                    }
+                ]
+            },
+            "/switch/on": {
+                "invokeAction": [
+                    {
+                        "method": "POST",
+                        "affordance": "sdfObject/Switch/sdfAction/on"
+                    }
+                ]
+            },
+            "/switch/off": {
+                "invokeAction": [
+                    {
+                        "method": "POST",
+                        "affordance": "sdfObject/Switch/sdfAction/off"
+                    }
+                ]
+            },
+            "/switch/toggle": {
+                "invokeAction": [
+                    {
+                        "method": "POST",
+                        "affordance": "sdfObject/Switch/sdfAction/toggle"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/jkrhb/sdf-binding-reversed.cddl
+++ b/jkrhb/sdf-binding-reversed.cddl
@@ -25,10 +25,7 @@ CoapBinding = {
     defaultSecurity: [+ tstr]; Must refer to keys from sdfSecurity
     host: tstr,
     ? port: (0..65535) .default 5683,
-    * tstr
-    "\/[^\/]+([^?#]+)": CoapPropertyAffordance
-    / CoapActionAffordance
-    / CoapEventAffordance,
+    * tstr: CoapPropertyAffordance / CoapActionAffordance / CoapEventAffordance; Can you define a regex pattern for the keys?
 }
 
 CoapPropertyAffordance = {
@@ -108,10 +105,7 @@ MqttBinding = {
     defaultSecurity: [+ tstr]; Must refer to keys from sdfSecurity
     brokerAddress: tstr,
     ? port: (0..65535) .default 1883,
-    * tstr
-    "[^+#]+": MqttPropertyAffordance; Key does not refer to a URI path but an MQTT topic
-    / MqttActionAffordance
-    / MqttEventAffordance,
+    * tstr: MqttPropertyAffordance / MqttActionAffordance / MqttEventAffordance; Key does not refer to a URI path but an MQTT topic
 }
 
 MqttPropertyAffordance = {
@@ -163,7 +157,8 @@ SdfSecurity = { * tstr: NoSecurity
     / APIKeySecurity
     / BearerSecurity
     / PSKSecurity
-    / OAuth2Security, }
+    / OAuth2Security,
+}
 
 Security = {
     ? @type: tstr,
@@ -171,13 +166,12 @@ Security = {
     ? proxy: uri,
 }
 
-NoSecurity = { Security, scheme: "nosec", }
+NoSecurity = {
+    Security,
+    scheme: "nosec",
+}
 
-SecurityIn = "header"
-    / "query"
-    / "body"
-    / "cookie"
-    / "uri"
+SecurityIn = "header" / "query" / "body" / "cookie" / "uri"
 
 BasicSecurity = {
     Security,
@@ -193,7 +187,11 @@ DigestSecurity = {
     ? in: SecurityIn,
 }
 
-APIKeySecurity = { Security, scheme: "api", ? in: SecurityIn, }
+APIKeySecurity = {
+    Security,
+    scheme: "api",
+    ? in: SecurityIn,
+}
 
 BearerSecurity = {
     Security,
@@ -205,7 +203,11 @@ BearerSecurity = {
     ? authorization: uri,
 }
 
-PSKSecurity = { Security, scheme: "psk", ? identity: tstr, }
+PSKSecurity = {
+    Security,
+    scheme: "psk",
+    ? identity: tstr,
+}
 
 OAuth2Security = {
     Security,

--- a/jkrhb/sdf-binding-reversed.cddl
+++ b/jkrhb/sdf-binding-reversed.cddl
@@ -1,0 +1,218 @@
+Binding = {
+    info: Info,
+    sdfSecurity: SdfSecurity,
+    sdfBindings: SdfBindings,
+}
+
+Info = {
+    title: tstr, 
+    ? description: tstr, 
+    ? id: uri,
+}
+
+SdfBindings = {
+    ? coap: CoapBinding,
+    ? http: HttpBinding,
+    ? mqtt: MqttBinding,
+}
+
+Operation = { 
+    ? security: [+ tstr]; Must refer to a keys from sdfSecurity 
+    affordance: tstr .regexp "[^/]([^/?#]+\/[^/?#]+)+[^/]", 
+}
+
+CoapBinding = {
+    defaultSecurity: [+ tstr]; Must refer to keys from sdfSecurity
+    host: tstr,
+    ? port: (0..65535) .default 5683,
+    * tstr
+    "\/[^\/]+([^?#]+)": CoapPropertyAffordance
+    / CoapActionAffordance
+    / CoapEventAffordance,
+}
+
+CoapPropertyAffordance = {
+    ? readProperty: [+ CoapReadOperation],
+    ? writeProperty: [+ CoapWriteOperation],
+    ? observeProperty: [+ CoapObserveOperation],
+    ? unobserveProperty: [+ CoapUnobserveOperation],
+}
+
+CoapActionAffordance = {
+    ? invokeAction: CoapInvokeOperation,
+}
+
+CoapEventAffordance = {
+    ? subscribeEvent: [+ CoapObserveOperation]; Similarity between observing a property and subscribing to an event makes it possible to reuse the observe and unobserve definitions
+    ? unsubscribeEvent: [+ CoapUnobserveOperation],
+}
+
+CoapMethod = "GET" / "POST" / "PUT" / "DELETE" / "FETCH" / "PATCH" / "iPATCH"
+
+CoapOperation = {
+    Operation,
+    * options: CoapOption,
+}
+
+CoapOption = {
+    name: tstr,
+    value: any,
+}
+
+CoapReadOperation = {
+    CoapOperation, 
+    ? method: CoapMethod .default "GET", 
+}
+
+CoapWriteOperation = {
+    CoapOperation,
+    ? method: CoapMethod .default "GET",
+}
+
+CoapObserveOperation = {
+    CoapOperation,
+    ? method: CoapMethod .default "GET",
+    ? options: [ * CoapOption ] .default CoapObserveOption, 
+}
+
+CoapUnobserveOperation = {
+    CoapOperation,
+    ? method: CoapMethod .default "GET",
+    ? options: [ * CoapOption ] .default CoapUnobserveOption,
+}
+
+CoapObserveOption = {
+    [
+        {
+            name: "Observe",
+            value: 0,
+        } 
+    ]
+}
+
+CoapUnobserveOption = {
+    [ 
+        {
+            name: "Observe",
+            value: 1,
+        }
+    ]
+}
+
+CoapInvokeOperation = {
+    Operation, 
+    ? method: CoapMethod .default "POST", 
+}
+
+MqttBinding = {
+    defaultSecurity: [+ tstr]; Must refer to keys from sdfSecurity
+    brokerAddress: tstr,
+    ? port: (0..65535) .default 1883,
+    * tstr
+    "[^+#]+": MqttPropertyAffordance; Key does not refer to a URI path but an MQTT topic
+    / MqttActionAffordance
+    / MqttEventAffordance,
+}
+
+MqttPropertyAffordance = {
+    ? writeProperty: [+ MqttWriteOperation],
+    ? observeProperty: [+ MqttSubscribeOperation]; Because of MQTT's PubSub pattern there is only observe, no read
+    ? unobserveProperty: [+ MqttUnsubscribeOperation],
+}
+
+MqttActionAffordance = {
+    ? invokeAction: [+ MqttInvokeOperation],
+}
+
+MqttEventAffordance = {
+    ? subscribeEvent: [+ MqttSubscribeOperation],
+    ? unsubscribeEvent: [+ MqttUnsubscribeOperation],
+}
+
+MqttOperation = {
+    Operation,
+    * options: MqttOption,
+}
+
+MqttWriteOperation = {
+    MqttOperation,
+    ? controlFlag: MqttControlFlag .default "PUBLISH",
+}
+
+MqttSubscribeOperation = {
+    MqttOperation,
+    ? controlFlag: MqttControlFlag .default "SUBSCRIBE",
+}
+
+MqttUnsubscribeOperation = {
+    MqttOperation,
+    affordance: int,
+    ? controlFlag: MqttControlFlag .default "UNSUBSCRIBE",
+}
+
+MqttControlFlag = "PUBLISH" / "SUBSCRIBE" / "UNSUBSCRIBE"; Should more flags be added?
+
+MqttOption = {
+    name: "qos" / "retain" / "dup",
+    value: 0..2,
+}
+
+SdfSecurity = { * tstr: NoSecurity
+    / BasicSecurity
+    / DigestSecurity
+    / APIKeySecurity
+    / BearerSecurity
+    / PSKSecurity
+    / OAuth2Security, }
+
+Security = {
+    ? @type: tstr,
+    ? description: tstr,
+    ? proxy: uri,
+}
+
+NoSecurity = { Security, scheme: "nosec", }
+
+SecurityIn = "header"
+    / "query"
+    / "body"
+    / "cookie"
+    / "uri"
+
+BasicSecurity = {
+    Security,
+    scheme: "basic",
+    name: tstr,
+    ? in: SecurityIn,
+}
+
+DigestSecurity = {
+    Security,
+    scheme: "digest",
+    ? qop: "auth" / "auth-int",
+    ? in: SecurityIn,
+}
+
+APIKeySecurity = { Security, scheme: "api", ? in: SecurityIn, }
+
+BearerSecurity = {
+    Security,
+    scheme: "bearer",
+    ? name: tstr,
+    ? in: SecurityIn,
+    ? alg: tstr,
+    ? format: tstr,
+    ? authorization: uri,
+}
+
+PSKSecurity = { Security, scheme: "psk", ? identity: tstr, }
+
+OAuth2Security = {
+    Security,
+    scheme: "oauth2",
+    flow: tstr,
+    ? scopes: [ + tstr ],
+    ? authorization: uri,
+    ? token: uri,
+    ? refresh: uri,
+}

--- a/jkrhb/sdf-switch.sdf.json
+++ b/jkrhb/sdf-switch.sdf.json
@@ -1,0 +1,33 @@
+{
+    "info": {
+        "title": "Example file for OneDM Semantic Definition Format",
+        "version": "2019-04-24",
+        "copyright": "Copyright 2019 Example Corp. All rights reserved.",
+        "license": "https://example.com/license"
+    },
+    "namespace": {
+        "cap": "https://example.com/capability/cap"
+    },
+    "defaultNamespace": "cap",
+    "sdfObject": {
+        "Switch": {
+            "sdfProperty": {
+                "value": {
+                    "description": "The state of the switch; false for off and true for on.",
+                    "type": "boolean"
+                }
+            },
+            "sdfAction": {
+                "on": {
+                    "description": "Turn the switch on; equivalent to setting value to true."
+                },
+                "off": {
+                    "description": "Turn the switch off; equivalent to setting value to false."
+                },
+                "toggle": {
+                    "description": "Toggle the switch; equivalent to setting value to its complement."
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds straw men examples for SDF procotol bindings (both a "regular" version and a "reversed" one) for the light switch definition from the SDF draft, and includes a first attempt to generalize the reversed binding in a CDDL schema definition. 

So far, the CDDL schema features bindings for CoAP and MQTT, and reuses [security definitions from WoT](https://www.w3.org/TR/wot-thing-description/#sec-security-vocabulary-definition). While the bindings themselves are also inspired by the [WoT Binding Templates](https://www.w3.org/TR/wot-binding-templates), they deviate in some aspects. This is especially the case when it comes to the allowed operations (as MQTT uses a publish-subscribe pattern, I excluded the `readProperty` operation in this case) and the definition of host/broker addresses which are now located in the respective protocol maps (as it may be conceivable that a device both acts as a CoAP server with its own host address and publishes messages to a broker with a different address).

With these measures and the "reversed" approach I think it could be possible to avoid some issues WoT is currently suffering from, especially when it comes to protocols like MQTT (where it is at the moment, for example, difficult to distinguish betwen URI paths and MQTT topics). 

I am looking forward to your comments and feedback! 